### PR TITLE
Fix build when using release build flag 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To compile and test this Dec 2025 option follow the instructions below (needs an
 * download this repo to a folder, in this demo assumed this to be `/repo/mdmc/`
 * somewhere else : `mkdir build`
 * then : `cd build/`
-* then : `cmake /repo/mdmc/src`
+* then : `cmake /repo/mdmc/src -DCMAKE_BUILD_TYPE=Release`
 * then : `make`
 * then : `cp /repo/mdmc/src/input/mdmc_control_time_corr_argon.xml bin/`
 * then : `cp /repo/mdmc/data/Van_Well_thesis_Ag_data/Well_s_q_omega_Ag_data_unsymmetrised.xml bin/`

--- a/src/mdmc.f90
+++ b/src/mdmc.f90
@@ -22,18 +22,15 @@ program mdmc
   integer :: exitstat
 
   ! set build in random generator function seeds
-  ! note only need to do this once 
-  !
-  ! Note I can't seem to force random_number to always
-  ! produce the same sequence of random numbers...
+  ! note only need to do this once
   
   integer :: n_seeds  
   logical :: output_dir_exist
   INTEGER, ALLOCATABLE :: new (:)
   call random_seed(size=n_seeds)
-  ALLOCATE (new(I))
+  ALLOCATE (new(n_seeds))
   new = 5
-  CALL RANDOM_SEED (PUT=new(1:I))
+  CALL RANDOM_SEED (PUT=new(1:n_seeds))
   
   ! A short welcome print to screen. Replace ... with release number and
   ! date for user releases


### PR DESCRIPTION
I tried building MDMC with `-DCMAKE_BUILD_TYPE=Release` and then running it but it crashes with some errors. I made some changes to fix these issues and updated the readme.

**To test**
Build MDMC with the release build flag. Running MDMC with mdmc_control_time_corr_argon.xml should be much faster, I find a 2x to 3x speed up.